### PR TITLE
Change header font to Open Sans

### DIFF
--- a/template/style.css.sass
+++ b/template/style.css.sass
@@ -2,8 +2,8 @@ $column_width: 26em
 $column_space: 0
 $column_count: auto
 
-@import url('https://fonts.googleapis.com/css?family=Open+Sans|Molengo|Ubuntu+Mono|Delius')
-$heading_font: 'Open Sans', Constantia, Palatino, serif
+@import url('https://fonts.googleapis.com/css?family=Comfortaa|Molengo|Ubuntu+Mono|Delius')
+$heading_font: Comfortaa, Constantia, Palatino, serif
 $content_font: Molengo, Calibri, Helvetica, sans-serif
 $literal_font: 'Ubuntu Mono', Monaco, Consolas, Fixedsys, monospace
 $quoting_font: Delius, Constantia, Palatino, serif


### PR DESCRIPTION
As it currently stands, the default header font (Audiowide) is honestly kind of garish. I'm a believer in good defaults, so I changed it to Open Sans, which I found to work well.

This is an opinionated request, but I think it's a good change to make.
