### PR TITLE
Make category stylings consistant

### DIFF
--- a/template/index.html.slim
+++ b/template/index.html.slim
@@ -30,8 +30,9 @@ html
                 td.title
                   a href=entry[:url]
                     = entry['title']
-                  .category
-                    = entry[:category]
+                  - unless entry[:categories].empty?
+                    .category
+                      | (#{entry[:category]})
                 td.date
                   - date = entry[:updated_at]
                   time datetime=date.iso8601

--- a/template/style.css.sass
+++ b/template/style.css.sass
@@ -87,10 +87,9 @@ $quoting_font: Delius, Constantia, Palatino, serif
       > .title > a.feed > img
         display: inline
 
-      > .category
-        margin-top: 1em
-        // Comment (zenburn.vim)
-        color: #7f9f7f
+    .category
+      // Comment (zenburn.vim)
+      color: #7f9f7f
 
     > .description
       +center_text


### PR DESCRIPTION
Previously, the category stylings used in entries and the category stylings used in the index were completely different. This fixes that, making sure you can easily tell it's the list of categories instead of just initially-meaningless white text.

I wasn't sure exactly where to put the .category style to make it less strict, so I kept it in the same place but removed its' body > header requirement.

![image](https://cloud.githubusercontent.com/assets/3432543/2870043/7591ffa0-d2a5-11e3-84ad-b72f3b10bb7d.png)
![image](https://cloud.githubusercontent.com/assets/3432543/2870045/86b905ee-d2a5-11e3-9672-b93a813f9df5.png)

(I'm sorry for all these pull requests, I've started using this and I'm trying to contribute back all the changes I think are useful. I've got a few more, but I'll wait a bit longer as to not swamp you completely.)
